### PR TITLE
Add --focus-interaction-behavior option for "opaque" inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # focus-shift
 
-focus-shift is a lightweight, zero-dependency JavaScript library designed for keyboard-based navigation in web applications. It restricts itself to shifting focus between elements in response to arrow key events. The behaviour of focus shifting can be guided by annotations in the HTML markup. This allows the library to work well with technologies that prefer generating HTML over interacting with JavaScript directly.
+focus-shift is a lightweight, zero-dependency JavaScript library designed for keyboard-based navigation in web applications. It restricts itself to shifting focus between elements in response to arrow key events. The behavior of focus shifting can be guided by annotations in the HTML markup. This allows the library to work well with technologies that prefer generating HTML over interacting with JavaScript directly.
 
 ## Features
 
@@ -43,6 +43,14 @@ The following attributes may be added in the markup to guide the moving of focus
 - `data-focus-prevent-scroll`: Prevents scrolling when the element receives focus.
 
 Setting `window.FOCUS_SHIFT_DEBUG = true` lets the library log processing steps to the browser's console.
+
+### CSS Options
+
+Some of focus-shift's behavior may be controlled using CSS, because it propagates nicely through the DOM tree, while allowing for overrides on individual elements or entire subtrees.
+
+- `--focus-interaction-behavior` determines behavior when arrow keys are pressed within input and textarea elements.
+  - `normal`: The default behavior of the browser will be preserved as much as possible. May come at the cost of input elements blocking spatial navigation.
+  - `opaque`: Input elements will be treated like other elements and focus will be shifted in the same way. Suitable for limited input devices (e.g. on-screen keyboards) and avoids ambiguities in interpreting arrow keys.
 
 ## Principles and Scope
 

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -252,6 +252,31 @@ describe("focus-shift spec", () => {
   )
 
   it(
+    "allows treating input elements as opaque",
+    testFor("./cypress/fixtures/interaction-behavior.html", { className: "" }, [
+      // Cypress does not seem to model cursors fully, which makes testing specifics of "normal"
+      // interaction behavior, i.e. moving the cursor within input text, brittle and difficult.
+      // We only verify a minimal expected difference between the modes: Whereas in normal mode
+      // arrow presses leave focus on the input in some cases, equivalent actions immediately
+      // shift focus in opaque mode.
+
+      // Input
+      { eventType: "focus", selector: "#normal-inputs [type=text]" },
+      { eventType: "keydown", selector: "#normal-inputs [type=text]", options: keyevent({ key: "ArrowRight" }) },
+      { eventType: "keydown", selector: "#normal-inputs [type=text]", options: keyevent({ key: "ArrowRight" }) },
+      { eventType: "focus", selector: "#opaque-inputs [type=text]" },
+      { eventType: "keydown", selector: "#opaque-inputs [type=number]", options: keyevent({ key: "ArrowRight" }) },
+      { eventType: "keydown", selector: "#opaque-inputs [type=email]", options: keyevent({ key: "ArrowRight" }) },
+      // Textarea
+      { eventType: "focus", selector: "#normal-inputs textarea" },
+      { eventType: "keydown", selector: "#normal-inputs textarea", options: keyevent({ key: "ArrowRight" }) },
+      { eventType: "keydown", selector: "#normal-inputs textarea", options: keyevent({ key: "ArrowRight" }) },
+      { eventType: "focus", selector: "#opaque-inputs textarea" },
+      { eventType: "keydown", selector: "#opaque-inputs button", options: keyevent({ key: "ArrowRight" }) }
+    ])
+  )
+
+  it(
     "allows canceling event handling",
     testFor("./cypress/fixtures/events.html", { className: "rows" }, [
       { eventType: "keydown", selector: "#button-1", options: keyevent({ key: "ArrowDown", repeat: false }) },

--- a/cypress/fixtures/interaction-behavior.html
+++ b/cypress/fixtures/interaction-behavior.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="nav-group" id="normal-inputs">
+      <h2>Normal behavior</h2>
+      <p>
+        <label>Text <input type="text" value="Text" /></label>
+        <label>Number <input type="number" value="1" /></label>
+        <label>Email <input type="email" value="email@example" /></label>
+        <label>URL <input type="url" value="https://example" /></label>
+      </p>
+      <p>
+        <textarea>Text</textarea>
+        <button>Focusable</button>
+      </p>
+    </div>
+
+    <div class="nav-group" style="--focus-interaction-behavior: opaque" id="opaque-inputs">
+      <h2>Opaque behavior</h2>
+      <p>
+        <label>Text <input type="text" value="Text" /></label>
+        <label>Number <input type="number" value="1" /></label>
+        <label>Email <input type="email" value="email@example" /></label>
+        <label>URL <input type="url" value="https://example" /></label>
+      </p>
+      <p>
+        <textarea>Text</textarea>
+        <button>Focusable</button>
+      </p>
+    </div>
+
+    <div class="nav-group" style="--focus-interaction-behavior: opaque">
+      <h2>Opaque behavior parent</h2>
+      <label>Number <input type="number" value="1" /></label>
+      <label style="--focus-interaction-behavior: normal"
+        >Normal behavior number <input type="number" value="1" id="renormalized-input"
+      /></label>
+    </div>
+
+    <script src="../../index.js"></script>
+  </body>
+</html>

--- a/examples/everything-bagel.html
+++ b/examples/everything-bagel.html
@@ -114,6 +114,10 @@
       <div>
         <label>Text <input type="text" /></label>
         <label>Number <input type="number" /></label>
+        <label
+          >Interactive Number
+          <input type="number" style="--focus-interaction-behavior: normal"
+        /></label>
         <label>Email <input type="email" /></label>
         <label>URL <input type="url" /></label>
       </div>

--- a/examples/everything-bagel.html
+++ b/examples/everything-bagel.html
@@ -104,6 +104,22 @@
       <div><button>Button 3</button></div>
     </div>
 
+    <div
+      class="nav-group"
+      data-focus-group
+      style="--focus-interaction-behavior: opaque"
+    >
+      <em>Default group</em>
+      <div><button>Button 1</button></div>
+      <div>
+        <label>Text <input type="text" /></label>
+        <label>Number <input type="number" /></label>
+        <label>Email <input type="email" /></label>
+        <label>URL <input type="url" /></label>
+      </div>
+      <div><button>Button 3</button></div>
+    </div>
+
     <div class="nav-group" data-focus-skip>
       <em>Skipped group</em>
       <button>Button 1</button>

--- a/index.js
+++ b/index.js
@@ -641,21 +641,19 @@ function isInputInteraction(direction, event) {
     return false
   }
 
+  const isTextarea = eventTarget.nodeName === "TEXTAREA"
+  const isInput = eventTarget.nodeName === "INPUT"
   const targetType = eventTarget.getAttribute("type")
-  const isTextualInput = [
-    "email",
-    "password",
-    "text",
-    "search",
-    "tel",
-    "url",
-    null
-  ].includes(targetType)
-  const isSpinnable =
+  const isTextualInput =
+    isInput &&
+    ["email", "password", "text", "search", "tel", "url", null].includes(
+      targetType
+    )
+  const isSpinnableInput =
     targetType != null &&
     ["date", "month", "number", "time", "week"].includes(targetType)
 
-  if (isTextualInput || isSpinnable || eventTarget.nodeName === "TEXTAREA") {
+  if (isTextualInput || isSpinnableInput || isTextarea) {
     // If there is a selection, assume user action is an input interaction
     if (eventTarget.selectionStart !== eventTarget.selectionEnd) {
       return true
@@ -669,19 +667,27 @@ function isInputInteraction(direction, event) {
         return false
       } else if (cursorPosition == null) {
         // If cursor position was not given, we always exit unless we see a "spinning" input
-        return isSpinnable && isVerticalMove
+        return isSpinnableInput && isVerticalMove
       } else if (cursorPosition === 0) {
         // Cursor at beginning
-        return direction === "right" || (isSpinnable && isVerticalMove)
+        return (
+          direction === "right" ||
+          (direction === "down" && isTextarea) ||
+          (isSpinnableInput && isVerticalMove)
+        )
       } else if (cursorPosition === eventTarget.value.length) {
         // Cursor at end
-        return direction === "left" || (isSpinnable && isVerticalMove)
+        return (
+          direction === "left" ||
+          (direction === "up" && isTextarea) ||
+          (isSpinnableInput && isVerticalMove)
+        )
       } else {
         // Cursor in middle
         return (
           direction === "left" ||
           direction === "right" ||
-          (isSpinnable && isVerticalMove)
+          (isVerticalMove && (isTextarea || isSpinnableInput))
         )
       }
     }

--- a/index.js
+++ b/index.js
@@ -627,7 +627,7 @@ function hasModifiers(e) {
  * Adapted from the Spatial Navigation Polyfill.
  *
  * Original Copyright (c) 2018-2019 LG Electronics Inc.
- * Source: https://github.com/WICG/spatial-navigation/polyfill
+ * Source: https://github.com/WICG/spatial-navigation/tree/main/polyfill
  * Licensed under the MIT license (MIT)
  *
  * @param {Direction} direction - The direction read from the keydown event


### PR DESCRIPTION
focus-shift uses special heuristics to preserve the "normal" interaction behavior of arrow keys on inputs and textareas:

- moving text cursor within the input text
- interact with the values, e.g. increment a number input's value on arrow up

In some scenarios this is not useful:

- a number input may block moving focus vertically within a form
- moving text cursor conflicts with controlling a virtual keyboard, both of which use the arrow keys, meaning both can not be active at the same time

In these scenarios it is more useful to treat input elements like any other focusable element and disable the internal arrow key interactions, i.e. we make the element "opaque" to focus-shift. This can be controlled by setting a CSS variable, so it is easy to declare all inputs on a page opaque, but override for individual elements if needed.

The main change is to disable our special heuristics in opaque mode, but to standardize where the immobile cursor is placed when an input element is focused, we always set it to the last text position for opaque inputs.